### PR TITLE
Added import/export functionality and moved config files to src/configs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,5 +101,4 @@ ENV/
 .mypy_cache/
 
 # CUSTOM
-src/configs
 releases/*/*

--- a/src/Recordurbate.py
+++ b/src/Recordurbate.py
@@ -8,7 +8,10 @@ from config import load_config, find_in_config, save_config
 
 def usage():
     print("\nUsage: Recordurbate [add | del] username")
-    print("       Recordurbate run\n")
+    print("       Recordurbate run")
+    print("       Recordurbate list")
+    print("       Recordurbate import list.txt")
+    print("       Recordurbate export [file location]\n")
 
 
 def main():
@@ -48,6 +51,52 @@ def main():
         bot = Bot()
         if not bot.error:
             bot.run()
+
+    #list command - outputs the list of streamers - usage: ./Recordurbate.py list
+    elif len(sys.argv) == 2 and sys.argv[1] == "list":
+        config = load_config()
+        print('Streamers in recording list:\n')
+        for streamer in config['streamers']:
+            print('- ' + streamer)
+
+    #Import command - Imports streamers from a txt file - Usage: ./Recordurbate.py import list.txt
+    elif len(sys.argv) == 3 and sys.argv[1] == "import":
+        config = load_config()
+
+        try:
+            import_file = open(sys.argv[2], "r") #Open file to import
+        except Exception as e:
+            print('Could not open the import file.', e)
+
+        for line in import_file: #For every username in the file
+            username = line.rstrip() #Get username
+
+            if username in config["streamers"]: #If username already exists, skip it
+                pass
+            else:
+                config["streamers"].append(username) #If username does not exist, add it to the config
+
+        if save_config(config): #Save config
+            print('Done...')
+
+    #Export command - Exports current streamer list as a file - Usage: ./Recordurbate.py export [file location] (Default location can be set in the config)
+    elif len(sys.argv) >= 2 and sys.argv[1] == "export":
+        config = load_config()
+
+        if len(sys.argv) == 3:
+            export_location = sys.argv[2] #If location is given, use it
+        else:
+            export_location = config["default_export_location"] #Else, use default location
+
+        try:
+            export_file = open(export_location, "w") #Open (or create) export file
+        except Exception as e:
+            print('Could not write to export location.', e)
+
+        for streamer in config["streamers"]:
+            export_file.write(streamer + '\n') #For every streamer in the config, write it to the file
+
+        print('Done...') 
 
     else:
         usage()

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -1,0 +1,8 @@
+{
+    "youtube-dl_cmd": "youtube-dl",
+    "youtube-dl_config": "configs/youtube-dl.config",
+    "auto_reload_config": true,
+    "default_export_location": "./list.txt",
+    "streamers": [
+    ]
+}

--- a/src/configs/youtube-dl.config
+++ b/src/configs/youtube-dl.config
@@ -1,0 +1,1 @@
+-o "videos/%(id)s/%(title)s.%(ext)s"


### PR DESCRIPTION
You can now import and export streamer lists as files

The config files are now in the src/configs folder so it's easier to make changes to them and you don't have to download a release for cloning the repo

Removed configs folder from .gitignore