### PR TITLE
Fixes-Issue-#68-Video-recording-get-very-big-in-file-size

### DIFF
--- a/recordurbate/configs/youtube-dl.config
+++ b/recordurbate/configs/youtube-dl.config
@@ -1,2 +1,5 @@
 -o "videos/%(id)s/%(title)s.%(ext)s"
+# To reduce output video filesize, use the following instead to limit to [height<1080][fps<?60]
+#-f 'best[height<1080][fps<?60]' -o "videos/%(id)s/%(title)s.%(ext)s"
 --quiet
+


### PR DESCRIPTION
Added new youtube-dl.config option (to be uncommented) for downloading 720p, 30fps