### PR TITLE
Let the is_online-function search for the specified username in roomlist

### DIFF
--- a/recordurbate/bot.py
+++ b/recordurbate/bot.py
@@ -66,26 +66,18 @@ class Bot:
                 self.config["streamers"].append([new_streamer, False])
 
     def is_online(self, username):
-        # Fixes issue #69 "Failed when calling is_online(..), new API url available."
-        # See the link below for full list of API parameters (gender, region, tag, limit, offset, etc..)
-        # Official Chaturbate API https://chaturbate.com/affiliates/promotools/api_usersonline/
-        # Special thanks to https://www.blackhatworld.com/seo/chaturbate-api.1028000/page-2#post-11041420
+        url = "https://chaturbate.com/api/ts/roomlist/room-list/?keywords=" + username
         
-        # With this API url, cam username must be in the first 500 results in order to be current_show="public" to be verified, due to max limit=500
-        # offset=(any non-negative number) can be included to obtain more results beyond the first 500.
-        MAX_API_RESULTS = "500" 
-        url = "https://chaturbate.com/api/public/affiliates/onlinerooms/?wm=DkfRj&client_ip=request_ip&limit=" + MAX_API_RESULTS
-
         try:
             time.sleep(3)  # fix issue 30
             r = requests.get(url)
-            results =  r.json()["results"]
+            rooms =  r.json()["rooms"]
             
             self.logger.debug(r)
-            self.logger.debug(results)
+            self.logger.debug(rooms)
             
-            for result in results:
-                if result["username"] == username and result["current_show"] in ["public"]:
+            for room in rooms:
+                if room["username"] == username and room["current_show"] in ["public"]:
                     return True
 
             return False


### PR DESCRIPTION
Previously the function would retrieve 500 rooms and check if the specified username is part of it and is online.
This not only is way too much data, this also doesn't guarantee to have the user, we are looking for, in it. Leading to the recording not starting.

I changed the code to use a different API call to only search by username and let chaturbate do the computing.